### PR TITLE
fix: generate tag from workflow_dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,20 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          TAG_NAME="${GITHUB_REF##*/}"             # e.g. v1.2.3
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            # 手動実行の場合、最新のタグを取得
+            TAG_NAME=$(git describe --tags --abbrev=0)
+          else
+            # タグpushの場合、そのタグを使用
+            TAG_NAME="${GITHUB_REF##*/}"
+          fi
+
+          # タグが取得できない場合のエラーハンドリング
+          if [ -z "$TAG_NAME" ]; then
+            echo "Error: No tag found"
+            exit 1
+          fi
+
           VERSION="${TAG_NAME#v}"                  # remove leading 'v'
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## 📌 概要 / Summary

- タグ取得ロジックの修正

## 🔧 変更内容 / Changes

- 手動実行時もタグが取得できるよう修正しました

## ✅ チェックリスト / Checklist

- [x] この変更は Issue / Discussion と関連しています（なければスキップ可）
- [x] ローカル環境でビルドとテストを実行しました（`dotnet build` / `dotnet test`）
- [x] 互換性や影響範囲について確認しました
- [x] 必要に応じてドキュメントを更新しました
- [x] ライセンスや著作権を侵害していないことを確認しました

## 🔍 関連する Issue / Related Issue

N/A

## 📝 備考 / Notes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release workflow to derive version from the latest tag during manual runs while preserving tag-push behavior.
  - Introduced validation to fail the workflow if a version cannot be determined, improving reliability.
  - Normalized VERSION by stripping a leading “v” for consistent downstream use.
  - Enhanced outputs for clearer consumption by subsequent steps in the publishing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->