### PR TITLE
fix: タグは入力するよう変更

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,15 @@ on:
         description: 'Tag to use (e.g., v1.2.3). If empty, uses latest tag.'
         required: false
         type: string
-
 env:
   PROJECT_PATH: 'src/Aivis.Net.csproj'
   ARTIFACT_STAGING_DIRECTORY: "artifacts"
   REPOSITORY_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+
+permissions:
+  contents: read        # リポジトリの内容を読み取り
+  packages: write       # パッケージの書き込み権限
+
 jobs:
   build:
     name: Build and Test


### PR DESCRIPTION
## 📌 概要 / Summary

- 手動実行時にタグ取得がうまく動かないので、手入力に変更

## 🔧 変更内容 / Changes

- タグを手動で入力するよう変更
 
## ✅ チェックリスト / Checklist

プルリクエストを提出する前に、以下のチェックを行ってください。

- [x] この変更は Issue / Discussion と関連しています（なければスキップ可）
- [x] ローカル環境でビルドとテストを実行しました（`dotnet build` / `dotnet test`）
- [x] 互換性や影響範囲について確認しました
- [x] 必要に応じてドキュメントを更新しました
- [x] ライセンスや著作権を侵害していないことを確認しました

## 🔍 関連する Issue / Related Issue

N/A

## 📝 備考 / Notes

手動実行でどうさすることを確認
https://github.com/Atoyr/Aivis.NET/actions/runs/17022916869/job/48254453337



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added manual publish trigger with optional tag input alongside release-triggered runs.
  - Refined version detection and validation, with clearer error handling when no tag is provided.
  - Updated build pipeline to include .NET 9 alongside existing .NET 8 steps.
  - Modernized NuGet/GitHub Packages publishing flow using dotnet-based configuration and push, with skip-duplicate safeguards.
  - Ensured version output is consistently propagated for artifacts.
  - Streamlined step naming and alignment for a more consistent publishing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->